### PR TITLE
Broken Sound Effects fix

### DIFF
--- a/src/main/java/de/teamlapen/werewolves/core/ModSounds.java
+++ b/src/main/java/de/teamlapen/werewolves/core/ModSounds.java
@@ -21,7 +21,7 @@ public class ModSounds {
     }
 
     private static RegistryObject<SoundEvent> create(String soundNameIn) {
-        ResourceLocation resourcelocation = new ResourceLocation(de.teamlapen.vampirism.REFERENCE.MODID, soundNameIn);
+        ResourceLocation resourcelocation = new ResourceLocation(REFERENCE.MODID, soundNameIn);
         return SOUND_EVENTS.register(soundNameIn, () -> SoundEvent.createVariableRangeEvent(resourcelocation));
     }
 }


### PR DESCRIPTION
Previously (since 7590588) , sound effects, that were added by this mod, did not work because they were registered using Vampirism's mod id.

This applied to things such as the sound effect when biting enemies and howling, meaning no sound was played. Noticed this today whilst testing werewolves in my Ageing addon.

Very simple fix, but wanted to make this a PR since I haven't done one before and wanted to learn how to use them properly but it seems reasonable enough for a pr. Because of that I'm not sure if something as simple as this should just be done through an issue.