### PR TITLE
updated werewolf rage logic to carry over when switching forms

### DIFF
--- a/src/main/java/de/teamlapen/werewolves/entities/player/werewolf/WerewolfPlayer.java
+++ b/src/main/java/de/teamlapen/werewolves/entities/player/werewolf/WerewolfPlayer.java
@@ -30,6 +30,7 @@ import de.teamlapen.werewolves.effects.WolfsbaneEffect;
 import de.teamlapen.werewolves.effects.inst.WerewolfNightVisionEffectInstance;
 import de.teamlapen.werewolves.entities.minion.WerewolfMinionEntity;
 import de.teamlapen.werewolves.entities.player.werewolf.actions.WerewolfFormAction;
+import de.teamlapen.werewolves.entities.player.werewolf.actions.RageWerewolfAction;
 import de.teamlapen.werewolves.mixin.FoodStatsAccessor;
 import de.teamlapen.werewolves.mixin.entity.PlayerAccessor;
 import de.teamlapen.werewolves.util.*;
@@ -112,6 +113,7 @@ public class WerewolfPlayer extends FactionBasePlayer<IWerewolfPlayer> implement
     private WerewolfForm form = WerewolfForm.NONE;
     @Nullable
     private WerewolfFormAction lastFormAction;
+    private boolean switchingForms = false;
     @Nonnull
     private final LevelHandler levelHandler = new LevelHandler(this);
 
@@ -138,7 +140,18 @@ public class WerewolfPlayer extends FactionBasePlayer<IWerewolfPlayer> implement
         this.lastFormAction = action;
         if (!this.player.level().isClientSide) {
             this.sync(NBTHelper.nbtWith(nbt -> nbt.putString("form", this.form.getName())), true);
+            if (this.actionHandler.isActionActive(ModActions.RAGE.get())) {
+                ModActions.RAGE.get().applyEffects(this);
+            }
         }
+    }
+
+    public boolean isSwitchingForms() {
+        return this.switchingForms;
+    }
+
+    public void setSwitchingForms(boolean switchingForms) {
+        this.switchingForms = switchingForms;
     }
 
     public WerewolfInventory getInventory() {

--- a/src/main/java/de/teamlapen/werewolves/entities/player/werewolf/actions/RageWerewolfAction.java
+++ b/src/main/java/de/teamlapen/werewolves/entities/player/werewolf/actions/RageWerewolfAction.java
@@ -70,9 +70,17 @@ public class RageWerewolfAction extends DefaultWerewolfAction implements ILastin
         return WerewolvesConfig.BALANCE.SKILLS.rage_cooldown.get() * 20;
     }
 
-    protected void applyEffects(IWerewolfPlayer werewolf) {
+    public void applyEffects(IWerewolfPlayer werewolf) {
         int speedAmplifier = werewolf.getForm() == WerewolfForm.SURVIVALIST ? 1 : 0;
         int damageAmplifier = werewolf.getForm() == WerewolfForm.BEAST ? 1 : 0;
+        MobEffectInstance currentSpeed = werewolf.asEntity().getEffect(MobEffects.MOVEMENT_SPEED);
+        if (currentSpeed != null && currentSpeed.getAmplifier() != speedAmplifier) {
+            removePotionEffect(werewolf, MobEffects.MOVEMENT_SPEED);
+        }
+        MobEffectInstance currentDamage = werewolf.asEntity().getEffect(MobEffects.DAMAGE_BOOST);
+        if (currentDamage != null && currentDamage.getAmplifier() != damageAmplifier) {
+            removePotionEffect(werewolf, MobEffects.DAMAGE_BOOST);
+        }
         addEffectInstance(werewolf, new MobEffectInstance(MobEffects.MOVEMENT_SPEED, 22, speedAmplifier, false, false));
         addEffectInstance(werewolf, new MobEffectInstance(MobEffects.DAMAGE_BOOST, 22, damageAmplifier, false, false));
     }

--- a/src/main/java/de/teamlapen/werewolves/entities/player/werewolf/actions/WerewolfFormAction.java
+++ b/src/main/java/de/teamlapen/werewolves/entities/player/werewolf/actions/WerewolfFormAction.java
@@ -117,7 +117,9 @@ public abstract class WerewolfFormAction extends DefaultWerewolfAction implement
         Player player = werewolf.asEntity();
         float healthPerc = player.getHealth() / player.getMaxHealth();
         if (isWerewolfFormActionActive(werewolf.getActionHandler())) {
+            ((WerewolfPlayer) werewolf).setSwitchingForms(true);
             FormHelper.deactivateWerewolfActions(werewolf);
+            ((WerewolfPlayer) werewolf).setSwitchingForms(false);
         }
         ((WerewolfPlayer) werewolf).setForm(this, this.form);
         this.checkDayNightModifier(werewolf);
@@ -144,7 +146,7 @@ public abstract class WerewolfFormAction extends DefaultWerewolfAction implement
         this.removeModifier(werewolf);
         player.setHealth(player.getMaxHealth() * healthPerc);
         player.refreshDisplayName();
-        if (werewolf.getActionHandler().isActionActive(ModActions.RAGE.get())) {
+        if (!((WerewolfPlayer) werewolf).isSwitchingForms() && werewolf.getActionHandler().isActionActive(ModActions.RAGE.get())) {
             werewolf.getActionHandler().deactivateAction(ModActions.RAGE.get());
         }
     }


### PR DESCRIPTION
It never made sense to me why Rage drops off when you switch werewolf forms. The skill tree clearly incentivizes switching forms based on the situation (Beast for attacking, Survivalist for running, and Partial to save transformation time on cooldown.) 
But actually switching during a fight is completely unviable right now because it nerfs you off by triggering a ~1-minute cooldown on Rage.

- Implemented **Rage carrying over forms** 
> -Duration time is shared across all forms (Beast, Partial and Survivalist)
> -Effects level will now update according to what form you switched to
> -Going into Beast Form will automatically trigger "Beast Rage" skill if you have it
> -Rage will deactivate if the player goes to human/vanilla form



